### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Pin Enonic libraries to next-major SNAPSHOTs published from master after their XP 8 upgrade. We are not releasing these libs yet, so consumers pin directly to the SNAPSHOTs.

### Bumped

| Lib | Before | After |
| --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` |

The new pin is a SNAPSHOT and resolves from the Enonic dev/snapshot Maven repo.

### Snapshot repo

`xp.enonicRepo("dev")` is already declared in the root `repositories {}` block — no change needed.

### Excludes audited

There are no `exclude` clauses on this dependency in `build.gradle`, so nothing to remove or keep.

## Verification

- `./gradlew clean build` — green.
- Runtime verification was not performed.

## Test plan

- [x] `./gradlew clean build` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)