### PR TITLE
Bump version to 4.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = onepager
 appName = com.enonic.app.onepager
 xpVersion = 8.0.0-B4
-version = 3.1.2-SNAPSHOT
+version = 4.0.0-SNAPSHOT


### PR DESCRIPTION
Branches the XP 7 maintenance line at `3.x` (post-release SNAPSHOT commit `399e8e5`) and bumps `master` to next-major SNAPSHOT.

## Changes

- `gradle.properties`: `version` `3.1.2-SNAPSHOT` → `4.0.0-SNAPSHOT`
- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` block listing both `master` and `3.x` so the release tooling treats both as release branches.

## Companion PR

A second PR against `3.x` adds the same `releaseBranch:` block on that branch (the build action reads the config from the branch's own workflow file). It does not include the version bump or any other master-only changes.

## Reference

Mirrors the approach used by [app-booster](https://github.com/enonic/app-booster) when its `1.x` maintenance branch was created (compare `master` and `1.x`).