### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -3,123 +3,27 @@ name: Gradle Build
 on: [ push ]
 
 jobs:
-  publish_vars:
-    runs-on: ubuntu-latest
-
-    outputs:
-      publish: ${{ github.ref == 'refs/heads/master' && steps.publish_vars.outputs.repo != '' }}
-      repo: ${{ steps.publish_vars.outputs.repo }}
-      release: ${{ github.ref == 'refs/heads/master' && steps.publish_vars.outputs.release == 'true' }}
-      tag_name: ${{ steps.publish_vars.outputs.tag_name }}
-      prerelease: ${{ steps.publish_vars.outputs.prerelease }}
-      nextSnapshot: ${{ steps.publish_vars.outputs.nextSnapshot }}
-
-    steps:
-
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: 11
-          distribution: 'adopt'
-
-      - name: Get publishing variables
-        id: publish_vars
-        uses: enonic/release-tools/publish-vars@master
-        env:
-          PROPERTIES_PATH: './gradle.properties'
-          GITHUB_REPO_PRIVATE: ${{github.event.repository.private}}
-
   build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
+  release:
     runs-on: ubuntu-latest
 
-    needs: [ publish_vars, release_notes ]
-    if: always()
+    needs: build
+    if: needs.build.outputs.release == 'true'
 
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
+      - uses: enonic/release-tools/release@master
         with:
-          java-version: 11
-          distribution: 'adopt'
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - run: ./gradlew build -Pcom.enonic.xp.app.production=true
-
-      - uses: codecov/codecov-action@v2.1.0
-
-      - name: Publish
-        if: needs.publish_vars.outputs.publish == 'true'
-        run: ./gradlew publish -Pcom.enonic.xp.app.production=true -PrepoKey=${{ needs.publish_vars.outputs.repo }} -PrepoUser=${{ secrets.ARTIFACTORY_USERNAME }} -PrepoPassword=${{ secrets.ARTIFACTORY_PASSWORD }}
-
-      - name: Download changelog
-        if: needs.publish_vars.outputs.release == 'true'
-        uses: actions/download-artifact@v2
-        with:
-          name: changelog
-
-      - name: Create Release
-        if: needs.publish_vars.outputs.release == 'true'
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.publish_vars.outputs.tag_name }}
-          body_path: changelog.md
-          prerelease: ${{ needs.publish_vars.outputs.prerelease == 'true' }}
-
-      - name: Write new snapshot version
-        if: needs.publish_vars.outputs.release == 'true'
-        uses: christian-draeger/write-properties@1.1.0
-        with:
-          path: './gradle.properties'
-          property: 'version'
-          value: ${{ needs.publish_vars.outputs.nextSnapshot }}
-
-      - name: Commit and push new version
-        if: needs.publish_vars.outputs.release == 'true'
-        uses: EndBug/add-and-commit@v7
-        with:
-          add: ./gradle.properties
-          message: 'Updated to next SNAPSHOT version'
-
-  release_notes:
-    runs-on: ubuntu-latest
-
-    needs: publish_vars
-    if: needs.publish_vars.outputs.release == 'true'
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Get previous release tag
-        id: get_previous_release_tag
-        run: |
-          PREVIOUS_RELEASE_TAG=$(git tag --sort=-version:refname --merged | grep -E '^v([[:digit:]]+\.){2}[[:digit:]]+$' | head -1)
-          echo ::set-output name=previous_release_tag::$PREVIOUS_RELEASE_TAG
-
-      - name: Generate Release Notes
-        uses: enonic/release-tools/generate-changelog@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
-          PREVIOS_RELEASE_TAG: ${{ steps.get_previous_release_tag.outputs.previous_release_tag }}
-          OUTPUT_FILE: changelog.md
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: changelog
-          path: changelog.md
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Aligns the `3.x` maintenance branch's CI workflow with `master` so the release tooling recognizes pushes to `3.x` as release-branch builds. The build action reads `releaseBranch:` from the branch's own workflow file, so this config has to live on `3.x` itself.

## Changes

- `.github/workflows/enonic-gradle.yml`: replace the older multi-job structure on `3.x` with the same modern `enonic/release-tools/build-and-publish@master` workflow used on `master`, and add a `releaseBranch:` block listing both `master` and `3.x`.

No version bump or other master-only changes are included here, per the [app-booster reference](https://github.com/enonic/app-booster) (compare `master` vs `1.x`).

## Companion PR

Pairs with #92 on `master`, which adds the same `releaseBranch:` block alongside the `4.0.0-SNAPSHOT` version bump.