### PR TITLE
Fix XP 8 startup and site rendering #94

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation xplibs.api.portal
     include xplibs.content
     include xplibs.portal
+    include xplibs.context
     include xplibs.export
     include xplibs.project
     include xplibs.cluster

--- a/src/main/resources/cms/pages/default/default.js
+++ b/src/main/resources/cms/pages/default/default.js
@@ -1,6 +1,6 @@
 var portalLib = require('/lib/xp/portal'),
     thymeleaf = require('/lib/thymeleaf'),
-    util = require('/lib/util');
+    util = require('/lib/util/data');
 
 // Handle GET request
 exports.get = handleGet;
@@ -23,7 +23,7 @@ function handleGet(req) {
                 pinterest: siteConfig.pinterest,
                 youtube: siteConfig.youtube
             },
-            addresses = util.data.forceArray(siteConfig.location),
+            addresses = util.forceArray(siteConfig.location),
             addressCols = getAddressCols(addresses);
 
         for (var i = 0; i < addresses.length; i++) {
@@ -58,7 +58,7 @@ function handleGet(req) {
     }
 
     function getMenuLayouts(content) {
-        var components = util.data.forceArray( content.page.regions.main.components ),
+        var components = util.forceArray( content.page.regions.main.components ),
             layouts = [],
             i, componentsLength = components.length;
 
@@ -77,7 +77,7 @@ function handleGet(req) {
 
     function getMetaKeywords(page) {
         var config = page.config,
-            metaKeywords = util.data.forceArray( config['meta-keywords'] ),
+            metaKeywords = util.forceArray( config['meta-keywords'] ),
             i, metaLength = metaKeywords.length;
 
         for (i = 0; i < metaLength; i++) {

--- a/src/main/resources/cms/parts/banner/banner.js
+++ b/src/main/resources/cms/parts/banner/banner.js
@@ -1,6 +1,6 @@
 var portal = require('/lib/xp/portal'),
     thymeleaf = require('/lib/thymeleaf'),
-    util = require('/lib/util');
+    util = require('/lib/util/data');
 
 // Handle GET request
 exports.get = handleGet;
@@ -27,7 +27,7 @@ function handleGet(req) {
         if (!banners) {
             return null;
         }
-        return util.data.forceArray(banners);
+        return util.forceArray(banners);
     }
 
     function ulClass() {

--- a/src/main/resources/cms/parts/features/features.js
+++ b/src/main/resources/cms/parts/features/features.js
@@ -1,6 +1,6 @@
 var portal = require('/lib/xp/portal'),
     thymeleaf = require('/lib/thymeleaf'),
-    util = require('/lib/util');
+    util = require('/lib/util/data');
 
 exports.get = handleGet;
 
@@ -20,7 +20,7 @@ function handleGet(req) {
         var model = {},
             component = portal.getComponent(),
             config = component.config,
-            features = util.data.forceArray(config.feature);
+            features = util.forceArray(config.feature);
 
         // Make it show the sample data when nothing is entered.
         if(!features[0] || (features[0].header == '' || features[0].header == null)) {

--- a/src/main/resources/cms/parts/gallery/gallery.js
+++ b/src/main/resources/cms/parts/gallery/gallery.js
@@ -1,7 +1,7 @@
 var contentLib = require('/lib/xp/content'),
     portal = require('/lib/xp/portal'),
     thymeleaf = require('/lib/thymeleaf'),
-    util = require('/lib/util');
+    util = require('/lib/util/data');
 
 exports.get = handleGet;
 
@@ -21,7 +21,7 @@ function handleGet(req) {
 
         var component = portal.getComponent(),
             config = component.config,
-            imageIDs = config.images ? util.data.forceArray(config.images) : null,
+            imageIDs = config.images ? util.forceArray(config.images) : null,
             contents = imageIDs? getImagesInOrder(imageIDs) : null;
 
         model.heading = config.heading || 'Missing heading';
@@ -82,7 +82,7 @@ function handleGet(req) {
             galleryItem = {};
             galleryItem.caption = imageContent.data.caption;
 
-            categories = util.data.forceArray(imageContent.data.tags);
+            categories = util.forceArray(imageContent.data.tags);
             liClass = 'gallery-item col-md-4 ';
             groups = '[';
 
@@ -149,7 +149,7 @@ function handleGet(req) {
             tags;
 
         for (i = 0, contentLength = contents.length; i < contentLength; i++) {
-            tags = util.data.forceArray(contents[i].data.tags);
+            tags = util.forceArray(contents[i].data.tags);
             for(j = 0, tagsLength = tags.length; j < tagsLength; j++) {
                 cats.push(tags[j]);
             }

--- a/src/main/resources/cms/parts/person-list/person-list.js
+++ b/src/main/resources/cms/parts/person-list/person-list.js
@@ -1,7 +1,7 @@
 var contentLib = require('/lib/xp/content'),
     portal = require('/lib/xp/portal'),
     thymeleaf = require('/lib/thymeleaf'),
-    util = require('/lib/util');
+    util = require('/lib/util/data');
 
 exports.get = handleGet;
 
@@ -23,7 +23,7 @@ function handleGet(req) {
             config = component.config,
             scrollerId = getId('people-scroller-', component),
             persons = [],
-            personContent = util.data.forceArray(config.person),
+            personContent = util.forceArray(config.person),
             i, j, x,
             person;
 

--- a/src/main/resources/lib/bootstrap-layout/index.js
+++ b/src/main/resources/lib/bootstrap-layout/index.js
@@ -1,6 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    util: require('/lib/util')
+    util: require('/lib/util/region')
 };
 
 /**
@@ -8,7 +8,7 @@ var libs = {
  * @returns {Array}
  */
 exports.getRegionsWithColumnInfo = function(defaultColumnConfig) {
-    var regions = libs.util.region.get(),
+    var regions = libs.util.get(),
         columnClasses = exports.getColumnClasses(defaultColumnConfig),
         i, len;
 

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -18,7 +18,8 @@ function runInContext(callback) {
     try {
         result = contextLib.run({
             principals: ["role:system.admin"],
-            repository: 'com.enonic.cms.' + projectData.id
+            repository: 'com.enonic.cms.' + projectData.id,
+            branch: 'master'
         }, callback);
     } catch (e) {
         log.info('Error: ' + e.message);


### PR DESCRIPTION
Closes #94

## What changed

Two unrelated XP 8 incompatibilities surfaced during E2E verification:

**1. Startup (`main.js`)**
- `build.gradle`: include `xplibs.context` so `/lib/xp/context` resolves.
  Without it the initializer's first require throws
  `ResourceNotFoundException: Resource [com.enonic.app.onepager:/lib/xp/context] was not found`.
- `main.js`: pass `branch: 'master'` to `contextLib.run`. XP 8's
  `InternalContext.Builder.build` rejects construction with
  `requireNonNull(branch, "branch is required")`, which makes the
  content-import step fail.

**2. Site rendering (`/lib/util` consumers)**
- `lib-util 4.0.0-SNAPSHOT`'s `index.js` eagerly imports
  `/lib/util/portal/getLocale`, which requires `/lib/xp/admin`. That lib
  isn't on the bundle's classpath, so any `require('/lib/util')` fails at
  request time with HTTP 500
  (`Resource [com.enonic.app.onepager:/lib/xp/admin] was not found`).
- Switch the five files that needed `forceArray` to
  `require('/lib/util/data')` and the one file that needed `region.get()`
  to `require('/lib/util/region')`. Both submodules are admin-free.

## How it was verified

XP 8.0.0-B4 boot in an isolated `/tmp/xp-e2e-*` install:

- App bundle reaches `ACTIVE`.
- `main.js` creates the `onepager` project and imports all 30 demo
  content nodes plus binaries — no errors.
- `GET /site/onepager/master/onepager` → 200, 23.6 KB, full one-pager
  HTML with banner, gallery, person-list, etc.
- Sampled `/_/asset/` and `/_/media:image/` URLs from the rendered page
  → 200.