### PR TITLE
Migrate to lib-asset #97

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     include xplibs.project
     include xplibs.cluster
     include libs.lib.thymeleaf
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     webjar "org.webjars:bootstrap:5.3.8"
     webjar "org.webjars:jquery:4.0.0"
     webjar "org.webjars:html5shiv:3.7.3-1"

--- a/src/main/resources/cms/pages/default/default.js
+++ b/src/main/resources/cms/pages/default/default.js
@@ -1,4 +1,5 @@
 var portalLib = require('/lib/xp/portal'),
+    assetLib = require('/lib/enonic/asset'),
     thymeleaf = require('/lib/thymeleaf');
 
 // Handle GET request
@@ -108,7 +109,7 @@ function handleGet(req) {
                 scale: 'height(25)'
             });
         } else {
-            return portalLib.assetUrl( {
+            return assetLib.assetUrl( {
                 path: 'images/acme-logo.png'
             });
         }

--- a/src/main/resources/cms/parts/person-list/person-list.js
+++ b/src/main/resources/cms/parts/person-list/person-list.js
@@ -1,5 +1,6 @@
 var contentLib = require('/lib/xp/content'),
     portal = require('/lib/xp/portal'),
+    assetLib = require('/lib/enonic/asset'),
     thymeleaf = require('/lib/thymeleaf');
 
 exports.get = handleGet;
@@ -63,7 +64,7 @@ function handleGet(req) {
                 persons[j].push({
                     name: personName || 'Missing Name',
                     title: personTitle || 'Missing Title',
-                    imageUrl: imageContentUrl || portal.assetUrl( {path: 'images/mer.jpg'}),
+                    imageUrl: imageContentUrl || assetLib.assetUrl( {path: 'images/mer.jpg'}),
                     pageUrl: pageUrl
                 });
             } else {
@@ -72,7 +73,7 @@ function handleGet(req) {
                 persons[j].push({
                     name: personName || 'Missing Name',
                     title: personTitle || 'Missing Title',
-                    imageUrl: imageContentUrl || portal.assetUrl( {path: 'images/mer.jpg'}),
+                    imageUrl: imageContentUrl || assetLib.assetUrl( {path: 'images/mer.jpg'}),
                     pageUrl: pageUrl
                 });
             }

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,1 +1,3 @@
 kind: "Site"
+apis:
+  - "asset"


### PR DESCRIPTION
Closes #97

Replaces the two `portal.assetUrl` call sites in this app's site context with `lib-asset`'s `assetUrl`, since `portal.assetUrl` is `@deprecated` in lib-portal.

## Changes

- `build.gradle`: add `include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"`.
- `src/main/resources/cms/site.yaml`: register the Universal API with `apis: ["asset"]`.
- `src/main/resources/cms/pages/default/default.js`: import `/lib/enonic/asset` and call `assetLib.assetUrl({path:'images/acme-logo.png'})` for the no-logo fallback.
- `src/main/resources/cms/parts/person-list/person-list.js`: same swap for the two `images/mer.jpg` fallback paths.

`/lib/xp/portal` is retained in both files because the controllers still call other `portal.*` functions (`getSite`, `getSiteConfig`, `imageUrl`, `getComponent`, `pageUrl`, `getContent`).

The Thymeleaf templates (`default.html`, error pages) reference `portal.assetUrl` through the Thymeleaf bridge object — that's a separate code path and is out of scope here.

## Test plan

- [x] `./gradlew build --refresh-dependencies` is clean.
- [x] Deploy `onepager.jar` into a fresh XP 8 runtime; bundle reaches ACTIVE (log: `Started application com.enonic.app.onepager bundle 117`).
- [x] Site renders at `http://localhost:8080/site/onepager/master/onepager` (HTTP 200).
- [x] **default.js fallback exercised**: with `siteConfig.logo` cleared, the rendered HTML emits `<img src="/site/onepager/master/onepager/_/com.enonic.app.onepager:asset/0000004a16dd9400/images/acme-logo.png"/>` and the URL returns `HTTP 200 image/png 1534 B`.
- [x] **person-list.js fallback exercised**: with a person's `image` reference cleared, the rendered HTML emits `<img class="img-fluid img-thumbnail rounded-circle" src="/site/onepager/master/onepager/_/com.enonic.app.onepager:asset/0000004a16dd9400/images/mer.jpg"/>` and the URL returns `HTTP 200 image/jpeg 16667 B`.