### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -8,9 +8,7 @@ const projectData = {
     displayName: 'One pager',
     description: 'Demo Enonic XP features',
     language: 'en',
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 
 function runInContext(callback) {


### PR DESCRIPTION
## Summary

`/lib/xp/project` got a flat-boolean shape on XP 8 master ([enonic/xp#12043](https://github.com/enonic/xp/pull/12043)): `readAccess: { public }` → `publicRead: boolean`. There's no back-compat shim, so the old shape fails at runtime.

This app only has one call site — the `projectData` literal in `src/main/resources/main.js` feeding `projectLib.create(...)` on startup. Swapped to `publicRead: true`.

No `projectLib.modify(...)` or `modifyReadAccess(...)` calls in the repo, so nothing else to migrate.

See the lib-project section of the [XP 8 upgrade notes](https://github.com/enonic/doc-code/blob/master/docs/upgrade.adoc) for the full API shape.

## Test plan

- [x] `./gradlew build` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)