### PR TITLE
Import fix: content.import attr, vacuum skip

### DIFF
--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,40 +1,19 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:output method="xml" indent="yes"/>
-  <xsl:param name="applicationId"/>
-  <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
-  <xsl:variable name="placeholderApp" select="'com.enonic.app.onepager'"/>
-  <xsl:variable name="placeholderAppDashed" select="translate($placeholderApp, '.', '-')"/>
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:param name="keepPublishFirst" select="'true'"/>
 
-  <xsl:template match="string[starts-with(text(),concat($placeholderApp,':'))]">
-    <string>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@name"/>
-      </xsl:attribute>
-      <xsl:value-of select="concat($applicationId, substring-after(.,$placeholderApp))"/>
-    </string>
-  </xsl:template>
+    <xsl:template match="data/property-set[@name='publish']">
+        <xsl:if test="$keepPublishFirst != 'false'">
+            <xsl:copy>
+                <xsl:apply-templates select="@*|*[@name='first']"/>
+            </xsl:copy>
+        </xsl:if>
+    </xsl:template>
 
-  <xsl:template match="string[text() = $placeholderApp]">
-    <string>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@name"/>
-      </xsl:attribute>
-      <xsl:value-of select="$applicationId"/>
-    </string>
-  </xsl:template>
-
-  <xsl:template match="property-set/@name[. = $placeholderAppDashed]">
-    <xsl:attribute name="name">
-      <xsl:value-of select="$applicationIdDashed"/>
-    </xsl:attribute>
-  </xsl:template>
-
-  <xsl:template match="@*|node()">
-    <xsl:copy>
-      <xsl:apply-templates select="@*|node()"/>
-    </xsl:copy>
-  </xsl:template>
-
-
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -62,6 +62,13 @@ function createContent() {
         xsltParams: {
             applicationId: app.name
         },
+        versionAttributes: {
+            'content.import': {
+                user: "role:system.admin",
+                optime: new Date().toISOString()
+            },
+            'vacuum.skip': {}
+        },
         includeNodeIds: true
     });
     log.info('-------------------');


### PR DESCRIPTION
## Summary

Mirrors the canonical fix in [enonic/app-features#248](https://github.com/enonic/app-features/pull/248) (also applied to [enonic/app-superhero-blog@dd30922](https://github.com/enonic/app-superhero-blog/commit/dd30922)).

- `replace_app.xsl` was dead weight: its placeholder-app rewriting templates had no effect because `placeholderApp` equals `app.name`. The XSLT now only cleans publish fields during import (keeping `publish.first`).
- Imported content now carries `content.import` and `vacuum.skip` version attributes, so vacuum can't reclaim bootstrap-imported content and downstream consumers can identify it.

## Test plan

- [x] `./gradlew build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)