### PR TITLE
Fix sorting by displayName #102

### DIFF
--- a/src/main/resources/import/onepager/_/node.xml
+++ b/src/main/resources/import/onepager/_/node.xml
@@ -650,6 +650,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/_templates/_/node.xml
+++ b/src/main/resources/import/onepager/_templates/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/_templates/default/_/node.xml
+++ b/src/main/resources/import/onepager/_templates/default/_/node.xml
@@ -298,6 +298,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/_/node.xml
+++ b/src/main/resources/import/onepager/people/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/bobby-westberg/_/node.xml
+++ b/src/main/resources/import/onepager/people/bobby-westberg/_/node.xml
@@ -181,6 +181,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/bobby-westberg/bwe.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/people/bobby-westberg/bwe.jpg/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/michael-lazell/_/node.xml
+++ b/src/main/resources/import/onepager/people/michael-lazell/_/node.xml
@@ -181,6 +181,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/michael-lazell/headshot-square.png/_/node.xml
+++ b/src/main/resources/import/onepager/people/michael-lazell/headshot-square.png/_/node.xml
@@ -205,6 +205,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/morten-eriksen/_/node.xml
+++ b/src/main/resources/import/onepager/people/morten-eriksen/_/node.xml
@@ -181,6 +181,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/morten-eriksen/mer.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/people/morten-eriksen/mer.jpg/_/node.xml
@@ -206,6 +206,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/thomas-sigdestad/_/node.xml
+++ b/src/main/resources/import/onepager/people/thomas-sigdestad/_/node.xml
@@ -181,6 +181,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/people/thomas-sigdestad/tsi.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/people/thomas-sigdestad/tsi.jpg/_/node.xml
@@ -206,6 +206,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/apartments.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/apartments.jpg/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/banner-pictures/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/banner-pictures/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/banner-pictures/legion.JPG/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/banner-pictures/legion.JPG/_/node.xml
@@ -223,6 +223,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/banner-pictures/stavanger.JPG/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/banner-pictures/stavanger.JPG/_/node.xml
@@ -209,6 +209,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/banner-pictures/vegas.JPG/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/banner-pictures/vegas.JPG/_/node.xml
@@ -223,6 +223,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/besseggen.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/besseggen.jpg/_/node.xml
@@ -237,6 +237,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/bogota.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/bogota.jpg/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/high-roller.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/high-roller.jpg/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/icons/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/icons/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/icons/acme-inc.png/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/icons/acme-inc.png/_/node.xml
@@ -205,6 +205,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/icons/clock.png/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/icons/clock.png/_/node.xml
@@ -205,6 +205,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/icons/graduate.png/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/icons/graduate.png/_/node.xml
@@ -205,6 +205,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/icons/high-school.png/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/icons/high-school.png/_/node.xml
@@ -205,6 +205,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/kobenhavn.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/kobenhavn.jpg/_/node.xml
@@ -237,6 +237,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/oslo-winter.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/oslo-winter.jpg/_/node.xml
@@ -237,6 +237,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/redwoods.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/redwoods.jpg/_/node.xml
@@ -237,6 +237,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/onepager/pictures/shanghai.jpg/_/node.xml
+++ b/src/main/resources/import/onepager/pictures/shanghai.jpg/_/node.xml
@@ -237,6 +237,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>


### PR DESCRIPTION
## Summary

Sorting by `displayName` was broken on demo content imported by the bundled importer: `childOrder` `displayName ASC/DESC` (and any sort using `_displayName`) did not match the collation used for freshly created content in Content Studio.

Root cause: the demo project is created with `language: 'en'` (`src/main/resources/main.js:10`), and XP's `LanguageConfigProcessor` applies a language-specific `pathIndexConfig` for `displayName` during `ContentService.create`. That ES `_orderby_en` field is what powers the language-aware sort. Imported nodes go through `exportLib.importNodes` and never hit that processor, so `_orderby_en` was empty for them.

Fix: add the same `pathIndexConfig` block to every `node.xml` under `src/main/resources/import/`. The settings mirror `IndexConfig.FULLTEXT` plus `addLanguage("en")` — i.e. what `LanguageConfigProcessor` produces — so imported content gets the same `_orderby_en` field as freshly created content.

Mirrors the same fix shipped for `app-superhero-blog` in https://github.com/enonic/app-superhero-blog/pull/172.

Closes #102

## Test plan

- [ ] `./gradlew build` is green (verified locally)
- [ ] Install/build the app on a fresh XP, run the demo importer, verify content sorts correctly by displayName in Content Studio
- [ ] Programmatic `findByParent` with sort `_displayName ASC` returns the imported children in the expected alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)